### PR TITLE
Recover decoder errors which are recoverable according to symphonia

### DIFF
--- a/src/sounds/decoders/symphonia.rs
+++ b/src/sounds/decoders/symphonia.rs
@@ -130,21 +130,10 @@ impl SymphoniaDecoder {
             let buf_ref = match self.decoder.decode(&packet) {
                 Ok(buf_ref) => buf_ref,
                 // Recoverable, but this packet is void. Expect weird noises!
-                Err(Error::IoError(err)) => {
-                    if err.kind() == std::io::ErrorKind::UnexpectedEof
-                        && err.to_string() == "end of stream"
-                    {
-                        // According to Symphonia this is the only way to detect an end of stream
-                        return Err(Error::IoError(err));
-                    } else {
-                        log::warn!("IoError while decoding stream: {}", err);
-                        continue;
-                    }
-                }
                 Err(Error::DecodeError(e)) => {
                     log::warn!("DecodeError while decoding stream: {}", e);
                     continue;
-                }
+                },
                 // Reset required, which is handled correctly by this decoder
                 Err(Error::ResetRequired) => continue,
                 // All other errors are unrecoverable


### PR DESCRIPTION
This should fix #1 

The end of stream detection is still not very nice, but that's on symphonia