### PR TITLE
Add device output stream sample format converter

### DIFF
--- a/src/backends/cpal_backend.rs
+++ b/src/backends/cpal_backend.rs
@@ -1,10 +1,14 @@
 //! [`CpalBackend`] outputs audio using the [cpal](https://www.docs.rs/cpal)
 //! crate.
 
-use crate::{manager::BackendSource, manager::Manager, Sound};
+use crate::{
+    manager::{BackendSource, Manager, Renderer},
+    Sound,
+};
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    BuildStreamError, PlayStreamError, StreamError,
+    BackendSpecificError, BuildStreamError, DefaultStreamConfigError, FromSample, PlayStreamError,
+    Sample, StreamError,
 };
 use std::error::Error;
 
@@ -17,6 +21,7 @@ pub use cpal::BufferSize as CpalBufferSize;
 pub struct CpalBackend {
     channel_count: u16,
     sample_rate: u32,
+    sample_format: cpal::SampleFormat,
     buffer_size: CpalBufferSize,
     device: cpal::Device,
     stream: Option<cpal::Stream>,
@@ -34,6 +39,7 @@ impl CpalBackend {
         let default_config = device.default_output_config().ok()?;
         let sample_rate = default_config.sample_rate().0;
         let channel_count = default_config.channels();
+        let sample_format = default_config.sample_format();
 
         Some(CpalBackend {
             channel_count,
@@ -41,6 +47,7 @@ impl CpalBackend {
             buffer_size: CpalBufferSize::Default,
             device,
             stream: None,
+            sample_format,
         })
     }
 
@@ -55,6 +62,7 @@ impl CpalBackend {
         let host = cpal::default_host();
 
         let device = host.default_output_device()?;
+        let sample_format = device.default_output_config().ok()?.sample_format();
 
         Some(CpalBackend {
             channel_count,
@@ -62,6 +70,7 @@ impl CpalBackend {
             buffer_size,
             device,
             stream: None,
+            sample_format,
         })
     }
 
@@ -71,6 +80,7 @@ impl CpalBackend {
         sample_rate: u32,
         buffer_size: CpalBufferSize,
         device: cpal::Device,
+        sample_format: cpal::SampleFormat,
     ) -> CpalBackend {
         CpalBackend {
             channel_count,
@@ -78,6 +88,7 @@ impl CpalBackend {
             buffer_size,
             device,
             stream: None,
+            sample_format,
         }
     }
 }
@@ -97,40 +108,73 @@ impl CpalBackend {
         let Ok(crate::NextSample::MetadataChanged) = renderer.next_sample() else {
             panic!("expected MetadataChanged event")
         };
-        let channel_count = self.channel_count;
-        let data_callback = move |buffer: &mut [i16], _info: &cpal::OutputCallbackInfo| {
-            assert!(buffer.len() % channel_count as usize == 0);
-            renderer.on_start_of_batch();
-
-            buffer.fill_with(|| {
-                let sample = renderer
-                    .next_sample()
-                    .expect("renderer should never return an Error");
-                match sample {
-                    crate::NextSample::Sample(s) => s,
-                    crate::NextSample::MetadataChanged => {
-                        unreachable!("we never change metadata mid-batch")
-                    }
-                    // TODO implement pausing
-                    crate::NextSample::Paused => 0,
-                    // TODO implement finishing
-                    crate::NextSample::Finished => 0,
-                }
-            });
-        };
 
         let config = cpal::StreamConfig {
             channels: self.channel_count,
             sample_rate: cpal::SampleRate(self.sample_rate),
             buffer_size: self.buffer_size,
         };
+
         let timeout = None;
-        let stream =
-            self.device
-                .build_output_stream(&config, data_callback, error_callback, timeout)?;
+        let stream = match self.sample_format {
+            cpal::SampleFormat::I16 => self.device.build_output_stream(
+                &config,
+                make_data_callback::<i16>(renderer, self.channel_count),
+                error_callback,
+                timeout,
+            )?,
+            cpal::SampleFormat::F32 => self.device.build_output_stream(
+                &config,
+                make_data_callback::<f32>(renderer, self.channel_count),
+                error_callback,
+                timeout,
+            )?,
+            sample_format => {
+                return Err(CpalBackendError::BuildStream(
+                    BuildStreamError::BackendSpecific {
+                        err: BackendSpecificError {
+                            description: format!(
+                                "unsupported output stream sample format: {:?}",
+                                sample_format
+                            ),
+                        },
+                    },
+                ))
+            }
+        };
+
         stream.play()?;
         self.stream = Some(stream);
         Ok(manager)
+    }
+}
+
+/// Converts Awedio's internal i16 samples to the format required by the audio device (type T).
+fn make_data_callback<T>(
+    mut renderer: Renderer,
+    channel_count: u16,
+) -> impl FnMut(&mut [T], &cpal::OutputCallbackInfo)
+where
+    T: Sample + FromSample<i16>,
+{
+    move |buffer: &mut [T], _info: &cpal::OutputCallbackInfo| {
+        assert!(buffer.len() % channel_count as usize == 0);
+
+        renderer.on_start_of_batch();
+
+        buffer.fill_with(|| {
+            let sample = renderer
+                .next_sample()
+                .expect("renderer should never return an Error");
+            match sample {
+                crate::NextSample::Sample(s) => T::from_sample(s),
+                crate::NextSample::MetadataChanged => {
+                    unreachable!("we never change metadata mid-batch")
+                }
+                crate::NextSample::Paused => T::from_sample(0), // TODO: implement pausing
+                crate::NextSample::Finished => T::from_sample(0), // TODO: implement finishing
+            }
+        });
     }
 }
 
@@ -154,6 +198,16 @@ impl From<BuildStreamError> for CpalBackendError {
 impl From<PlayStreamError> for CpalBackendError {
     fn from(inner: PlayStreamError) -> Self {
         CpalBackendError::PlayStream(inner)
+    }
+}
+
+impl From<DefaultStreamConfigError> for CpalBackendError {
+    fn from(inner: DefaultStreamConfigError) -> Self {
+        CpalBackendError::BuildStream(BuildStreamError::BackendSpecific {
+            err: BackendSpecificError {
+                description: format!("default stream config error: {:?}", inner),
+            },
+        })
     }
 }
 


### PR DESCRIPTION
1. Not sure if we want to add all the sample formats, I have only seen f32 and i16, so I omitted the others to keep it readable without macros.
2. Error handling/conversion is a bit tricky, I tried to avoid to add new error types, let me know how you'd like it
3. I think it would be nice to have a constructor that accepts [SupportedStreamConfig](https://docs.rs/cpal/0.15.3/cpal/struct.SupportedStreamConfig.html#) directly. Less code and easier to validate that the config will work before starting.
4. Would be cool with some tests, I will see what I can do 🤓 

Fixes #3 