### PR TITLE
Play sounds directly from bytes

### DIFF
--- a/src/sounds.rs
+++ b/src/sounds.rs
@@ -4,6 +4,7 @@ pub mod wrappers;
 
 mod empty;
 mod memory_sound;
+mod open_bytes;
 mod open_file;
 mod silence;
 mod sine_wave;
@@ -14,6 +15,7 @@ mod sounds_from_fn;
 pub use empty::Empty;
 pub use memory_sound::MemorySound;
 pub use memory_sound::UnsupportedMetadataChangeError;
+pub use open_bytes::open_bytes;
 pub use open_file::open_file;
 pub use open_file::open_file_with_buffer_capacity;
 pub use silence::Silence;

--- a/src/sounds.rs
+++ b/src/sounds.rs
@@ -16,6 +16,7 @@ pub use empty::Empty;
 pub use memory_sound::MemorySound;
 pub use memory_sound::UnsupportedMetadataChangeError;
 pub use open_bytes::open_bytes;
+pub use open_bytes::open_reader;
 pub use open_file::open_file;
 pub use open_file::open_file_with_buffer_capacity;
 pub use silence::Silence;

--- a/src/sounds/open_bytes
+++ b/src/sounds/open_bytes
@@ -1,0 +1,4 @@
+use crate::Sound;
+use std::{fs::File, io::BufReader};
+
+pub fn 

--- a/src/sounds/open_bytes
+++ b/src/sounds/open_bytes
@@ -1,4 +1,0 @@
-use crate::Sound;
-use std::{fs::File, io::BufReader};
-
-pub fn 

--- a/src/sounds/open_bytes.rs
+++ b/src/sounds/open_bytes.rs
@@ -1,0 +1,41 @@
+use crate::Sound;
+
+/// Create a Sound from bytes. This is best used with [std::include_bytes!], as the bytes must have
+/// a static lifetime.
+///
+/// It tries to autodetect the file type
+///
+/// If the file type is not able to be decoded then an
+/// [std::io::ErrorKind::Unsupported] is returned.
+///
+/// Like [crate::sounds::open_file], you may want to use it in conjunction with
+/// [crate::sounds::memory_sound] to be cheaper.
+pub fn open_bytes(bytes: &'static [u8]) -> Result<Box<dyn Sound>, crate::Error> {
+    use std::io::Cursor;
+
+    // underscore here so we don't get warnings with the features
+    #[cfg(feature = "rmp3-mp3")]
+    let _error = match super::decoders::Mp3Decoder::new(bytes) {
+        Err(e) => e,
+        Ok(decoder) => return Ok(Box::new(decoder)),
+    };
+
+    #[cfg(feature = "qoa")]
+    let _error = match super::decoders::QoaDecoder::new(bytes) {
+        Err(e) => e,
+        Ok(decoder) => return Ok(Box::new(decoder)),
+    };
+
+    #[cfg(feature = "hound-wav")]
+    let _error = match super::decoders::WavDecoder::new(bytes) {
+        Err(e) => e,
+        Ok(decoder) => return Ok(Box::new(decoder)),
+    };
+
+    #[cfg(feature = "symphonia")]
+    let _error = match super::decoders::SymphoniaDecoder::new(Box::new(Cursor::new(bytes)), None) {
+        Err(e) => e,
+        Ok(decoder) => return Ok(Box::new(decoder)),
+    };
+    Err(_error.into())
+}

--- a/src/sounds/open_bytes.rs
+++ b/src/sounds/open_bytes.rs
@@ -1,39 +1,55 @@
 use crate::Sound;
+use std::io::Read;
+#[cfg(feature = "symphonia")]
+use symphonia::core::io::MediaSource;
 
 /// Create a Sound from bytes. This is best used with [std::include_bytes!], as the bytes must have
 /// a static lifetime.
 ///
-/// It tries to autodetect the file type
-///
-/// If the file type is not able to be decoded then an
-/// [std::io::ErrorKind::Unsupported] is returned.
-///
-/// Like [crate::sounds::open_file], you may want to use it in conjunction with
-/// [crate::sounds::memory_sound] to be cheaper.
-pub fn open_bytes(bytes: &'static [u8]) -> Result<Box<dyn Sound>, crate::Error> {
+/// It tries to autodetect the file type.
+pub fn open_bytes<T: AsRef<[u8]> + std::marker::Sync>(
+    bytes: &'static T,
+) -> Result<Box<dyn Sound>, crate::Error> {
     use std::io::Cursor;
+    open_reader(Cursor::new(bytes))
+}
+
+/// Create a Sound from a reader.
+/// It tries to autodetect the file type.
+pub fn open_reader<R: Read + Send + MediaSource + 'static>(
+    mut reader: R,
+) -> Result<Box<dyn Sound>, crate::Error> {
+    let _error: crate::Error = std::io::Error::from(std::io::ErrorKind::Unsupported).into();
+
+    #[cfg(feature = "rmp3-mp3")]
+    // This is commented out because MP3Decoder doesn't
+    // return a Result. For now, in that case we just fail
+
+    // let __error = match super::decoders::Mp3Decoder::new(reader.by_ref()) {
+    //     Err(e) => e,
+    //     Ok(decoder) => return Ok(Box::new(decoder)),
+    // };
 
     // underscore here so we don't get warnings with the features
-    #[cfg(feature = "rmp3-mp3")]
-    let _error = match super::decoders::Mp3Decoder::new(bytes) {
-        Err(e) => e,
-        Ok(decoder) => return Ok(Box::new(decoder)),
-    };
+    let _error: crate::Error = std::io::Error::from(std::io::ErrorKind::Unsupported).into();
 
     #[cfg(feature = "qoa")]
-    let _error = match super::decoders::QoaDecoder::new(bytes) {
+    // Seems to be a little messy but is the best I could come up
+    // with so we could reuse reader if there are multiple features
+    // at once
+    let _error = match super::decoders::QoaDecoder::new(reader.by_ref()) {
         Err(e) => e,
-        Ok(decoder) => return Ok(Box::new(decoder)),
+        Ok(_) => return Ok(Box::new(super::decoders::QoaDecoder::new(reader).unwrap())),
     };
 
     #[cfg(feature = "hound-wav")]
-    let _error = match super::decoders::WavDecoder::new(bytes) {
+    let _error = match super::decoders::WavDecoder::new(reader.by_ref()) {
         Err(e) => e,
-        Ok(decoder) => return Ok(Box::new(decoder)),
+        Ok(_) => return Ok(Box::new(super::decoders::WavDecoder::new(reader).unwrap())),
     };
 
     #[cfg(feature = "symphonia")]
-    let _error = match super::decoders::SymphoniaDecoder::new(Box::new(Cursor::new(bytes)), None) {
+    let _error = match super::decoders::SymphoniaDecoder::new(Box::new(reader), None) {
         Err(e) => e,
         Ok(decoder) => return Ok(Box::new(decoder)),
     };


### PR DESCRIPTION
I am using awedio for a project, and it embeds audio files to the program with include_bytes! macro
In order to play these sounds I'd have to save them to disk and then reload them. Not ideal

So here I present you the `open_bytes` function which loads audio from a bytes instead of from a file.

It can be used like this 
```rust
let (mut manager, _backend) = awedio::start().unwrap();
manager.play(awedio::sounds::open_bytes(include_bytes!("../my_audio.mp3")).unwrap());
``` 

Note that the bytes must have a static lifetime, but it wouldn't be an issue most of the time (especially with include_bytes)